### PR TITLE
Support bare SOPS objects in decryptSops

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,38 @@ const decrypted = await decryptSops({
 });
 ```
 
+### `decryptSops(sopsObject, options?)`
+
+Decrypts SOPS-encrypted content directly from a pre-parsed SOPS object.
+
+```js
+const sopsObject = {
+  secret:
+    "ENC[AES256_GCM,data:trrpgezXug4Dq9T/inwkMA==,iv:glPwxoY2UuHO91vlJRaqYtFkPY1VsWvkJtfkEKZJdns=,tag:v7DbOYl7C5gdQRdW6BVoLw==,type:str]",
+  sops: {
+    kms: null,
+    gcp_kms: null,
+    azure_kv: null,
+    hc_vault: null,
+    age: [
+      {
+        recipient:
+          "age1je6kjhzuhdjy3fqptpttxjh5k8q46vygzlgtpuq3030c947pc5tqz9dqvr",
+        enc: "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsYVh6WTdzNnArL1E1RVVw\nZEoyU2hqZVZuVjR3bFJ2dlZaOGQ4VUVla1hVCll3MDZrY1VZeWtPNzVPUGNFWjBK\ncDZLVFZheU4wK0hBOTNmRFcwUkE4OFkKLS0tIHl3Y0x5Sk9lVDRCQkR3QzNzRWY4\ncFNPWFZqdEtyUmFhL3pLOHJvNlhuTTAKNLKVIFujPtmpYo/Oycit0JbcfPVN2TN5\nG9emUjK1XVOwkNda0olhEt4KAjSBV7dYt8luOL8VQeR33PadX7RK3A==\n-----END AGE ENCRYPTED FILE-----\n",
+      },
+    ],
+    lastmodified: "2024-12-25T09:03:17Z",
+    mac: "ENC[AES256_GCM,data:pjgkspXlmS1uFtR5yRZXcXISNEOk2/L4lN1zJoo49kgbABun2EwpZ2wfhPUDEDKn7kfmKuSOl4xQ/adUHVJh6bOHyQTf9lfH2BekCy828BIODowzk2tR5uiin8bB5q5VQfNJIaYEn3EWpGaOupEaNTZOyi5ML+WXB8s6w53Wg0w=,iv:wKEh9xSZ5RtsNdlRcEpYnbLKmUV6yitneJQhVt7qBSM=,tag:CmfHyYRe2/GVEexW5A8OWg==,type:str]",
+    pgp: null,
+    unencrypted_suffix: "_unencrypted",
+    version: "3.9.2",
+  },
+};
+
+// Assumes SOPS_AGE_KEY is set in the env
+const decrypted = await decryptSops(sopsObject);
+```
+
 ### Options
 
 The `decryptSops` function accepts the following options:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sops-age",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "sops age decryption for JavaScript",
   "repository": "humphd/sops-age",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,12 @@ export async function decryptSops(
     return decrypt(sopsData, decryptOptions);
   }
 
+  // Case 3. An bare input object with no options (AGE key must be set in the env)
+  if (inputOrOptions && isSopsInput(inputOrOptions)) {
+    const sopsData = await parseSops(inputOrOptions);
+    return decrypt(sopsData, {});
+  }
+
   throw new Error(
     "Invalid options: when no input given, you must specify one of `path` or `url`",
   );

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -15,7 +15,7 @@ const AGE_SECRET_KEY =
   "AGE-SECRET-KEY-1QXRVEJH9S4NQU0FPD6V79ESZQ8S6PXH3L8V40EVPTHFH6KNKD4DQ7SKC4P";
 
 describe("decryptSops()", () => {
-  test.only("with valid object input", async () => {
+  test("with valid object input", async () => {
     const value = await decryptSops(test_secret_enc_json);
     expect(value).toEqual(test_secret_json);
   });

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -15,6 +15,17 @@ const AGE_SECRET_KEY =
   "AGE-SECRET-KEY-1QXRVEJH9S4NQU0FPD6V79ESZQ8S6PXH3L8V40EVPTHFH6KNKD4DQ7SKC4P";
 
 describe("decryptSops()", () => {
+  test.only("with valid object input", async () => {
+    const value = await decryptSops(test_secret_enc_json);
+    expect(value).toEqual(test_secret_json);
+  });
+
+  test("with invalid object input", async () => {
+    await expect(
+      decryptSops({ missing: "sops", invalid: true }),
+    ).rejects.toThrow();
+  });
+
   test("with direct input", async () => {
     const value = await decryptSops(JSON.stringify(test_secret_enc_json), {
       secretKey: AGE_SECRET_KEY,


### PR DESCRIPTION
From Discord:

>import { decryptSops } from "npm:sops-age@3.2.0";
>
>const {
>  OPENROUTER_API_KEY,
>  GROQ_API_KEY,
>  SAMBANOVA_API_KEY
>} = await decryptSops(JSON.stringify(secrets), {fileType: "json"});
>a little weird to have to stringify again 🙂

This add support for being able to do this:

```ts
import { decryptSops } from "npm:sops-age@3.3.0";

const {
  OPENROUTER_API_KEY,
  GROQ_API_KEY,
  SAMBANOVA_API_KEY
} = await decryptSops(secrets);
```