### PR TITLE
Update to age-encryption v0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@noble/ciphers": "^1.2.1",
-    "age-encryption": "^0.2.1",
+    "age-encryption": "^0.2.3",
     "dotenv": "^16.4.7",
     "lodash": "^4.17.21",
     "yaml": "^2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       age-encryption:
-        specifier: ^0.2.1
-        version: 0.2.1
+        specifier: ^0.2.3
+        version: 0.2.3
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -1126,8 +1126,8 @@ packages:
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
-  age-encryption@0.2.1:
-    resolution: {integrity: sha512-EGiFGUoXi02A16tgXTGPi5wt3osmNbjrT7uPAEXs1NxAMFdklW/LWJ5dPx88ZEJF/kRF9zIWDBQoN4ArOjNM8w==}
+  age-encryption@0.2.3:
+    resolution: {integrity: sha512-8lAcfFbLENeRa+7cznNi0Pzq9fCoiWGHByZ5v04JmVea6tK5lDbPQa3sbZe5RyJNSWN4zMNMguB5uI8BCnxXNw==}
 
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
@@ -4270,7 +4270,7 @@ snapshots:
 
   add-stream@1.0.0: {}
 
-  age-encryption@0.2.1:
+  age-encryption@0.2.3:
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1


### PR DESCRIPTION
Updating to https://github.com/FiloSottile/typage/releases/tag/v0.2.3