### PR TITLE
Proper sops age key handling

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -3,6 +3,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: nhedger/setup-sops@v2
+      - uses: alessiodionisi/setup-age-action@v1.3.0
       - uses: ./.github/actions/prepare
       - run: pnpm run test:unit
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ## Features
 
 - Supports decryption of SOPS files encrypted with `age`
+- Automatic age key discovery, following SOPS conventions
+- SSH key support, automatically converting Ed25519 and RSA SSH keys to age format
 - Compatible with various file formats including `.env`, `.json`, and `.yaml`
 - Supports multiple input types (`string`, `Buffer`, `File`, `Blob`, streams, etc.)
 - Works across different JavaScript runtimes (Node.js, Deno, Bun, browser)
@@ -35,7 +37,12 @@ The library can be used in various JavaScript environments and supports multiple
 ```js
 import { decryptSops } from "sops-age";
 
-// Decrypt from a local file
+// Decrypt from a local file (keys auto-discovered from env and file system)
+const config = await decryptSops({
+  path: "./config.enc.json",
+});
+
+// Or with explicit age key
 const config = await decryptSops({
   path: "./config.enc.json",
   secretKey: "AGE-SECRET-KEY-1qgdy...",
@@ -94,13 +101,12 @@ The library provides a unified `decryptSops` function that can handle various in
 ```js
 import { decryptSops } from "sops-age";
 
-// Decrypt from a local file
+// Decrypt from a local file, auto-discovering age keys
 const config = await decryptSops({
   path: "./config.enc.json",
-  secretKey: "AGE-SECRET-KEY-1qgdy...",
 });
 
-// Decrypt from a URL
+// Decrypt from a URL with explicit age key
 const remoteConfig = await decryptSops({
   url: "https://example.com/config.enc.yaml",
   secretKey: "AGE-SECRET-KEY-1qgdy...",
@@ -136,6 +142,91 @@ The library automatically detects the file type based on file extension or conte
 - `Buffer`: Node.js Buffer (in Node.js environment)
 - `ReadableStream<Uint8Array>`: Stream of binary data
 
+## Age Key Discovery
+
+`sops-age` automatically discovers age keys using the same logic as SOPS itself. When no `secretKey` is explicitly provided, the library will search for keys in the following order:
+
+### 1. SSH Keys (Converted to Age Format)
+
+The library can automatically convert SSH private keys to age format:
+
+- **Environment variable**: `SOPS_AGE_SSH_PRIVATE_KEY_FILE` - path to SSH private key
+- **Default locations**: `~/.ssh/id_ed25519` and `~/.ssh/id_rsa` (in that order)
+- **Supported types**: Ed25519 and RSA keys
+
+```js
+// Set environment variable to use specific SSH key
+process.env.SOPS_AGE_SSH_PRIVATE_KEY_FILE = "/path/to/my/ssh/key";
+
+// Keys will be auto-discovered and converted
+const config = await decryptSops({ path: "./config.enc.json" });
+```
+
+### 2. Age Keys from Environment Variables
+
+- **`SOPS_AGE_KEY`**: Direct age private key
+- **`SOPS_AGE_KEY_FILE`**: Path to file containing age keys
+- **`SOPS_AGE_KEY_CMD`**: Command that outputs age keys
+
+```js
+// Direct key
+process.env.SOPS_AGE_KEY = "AGE-SECRET-KEY-1qgdy...";
+
+// Key file
+process.env.SOPS_AGE_KEY_FILE = "/path/to/keys.txt";
+
+// Command that outputs keys
+process.env.SOPS_AGE_KEY_CMD = "my-key-manager get-age-key";
+```
+
+### 3. Default Config File
+
+The library checks for age keys in the default SOPS config directory:
+
+- **Linux/Unix**: `~/.config/sops/age/keys.txt` (or `$XDG_CONFIG_HOME/sops/age/keys.txt`)
+- **macOS**: `~/Library/Application Support/sops/age/keys.txt` (or `$XDG_CONFIG_HOME/sops/age/keys.txt` if set)
+- **Windows**: `%APPDATA%\sops\age\keys.txt`
+
+Example `keys.txt` file:
+
+```text
+# Created: 2024-01-15T10:30:00Z
+# Public key: age1je6kjhzuhdjy3fqptpttxjh5k8q46vygzlgtpuq3030c947pc5tqz9dqvr
+AGE-SECRET-KEY-1QGDY7NWZDM5HG2QMSKQHQZPQF2QJLTQHQZPQF2QJLTQHQZPQF2QJLTQHQZ
+
+# Another key
+AGE-SECRET-KEY-1ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOP
+```
+
+## Key Discovery Priority
+
+When no explicit `secretKey` is provided, keys are discovered in this order:
+
+1. **SSH Keys**: `SOPS_AGE_SSH_PRIVATE_KEY_FILE` → `~/.ssh/id_ed25519` → `~/.ssh/id_rsa`
+2. **Age Keys**: `SOPS_AGE_KEY` → `SOPS_AGE_KEY_FILE` → `SOPS_AGE_KEY_CMD`
+3. **Default Config**: Platform-specific `sops/age/keys.txt` file
+
+The library will try all discovered keys until one successfully decrypts the file.
+
+## Age Key Utilities
+
+The library includes utilities for discovering age keys and converting SSH keys to age format:
+
+```js
+import { sshKeyToAge, sshKeyFileToAge, findAllAgeKeys } from "sops-age";
+
+// Convert SSH key content to age format
+const sshKeyContent = "-----BEGIN OPENSSH PRIVATE KEY-----\n...";
+const ageKey = sshKeyToAge(sshKeyContent);
+
+// Convert SSH key file to age format
+const ageKey = await sshKeyFileToAge("/path/to/ssh/key");
+
+// Discover all available age keys
+const allKeys = await findAllAgeKeys();
+console.log("Found keys:", allKeys);
+```
+
 ## API Reference
 
 ### `decryptSops(input, options?)`
@@ -143,6 +234,12 @@ The library automatically detects the file type based on file extension or conte
 Decrypts SOPS-encrypted content directly from a string, Buffer, or other supported input types.
 
 ```js
+// With auto-discovered keys
+const decrypted = await decryptSops(jsonString, {
+  fileType: "json",
+});
+
+// With explicit key
 const decrypted = await decryptSops(jsonString, {
   secretKey: "AGE-SECRET-KEY-1qgdy...",
   fileType: "json",
@@ -156,7 +253,7 @@ Decrypts a SOPS-encrypted file from the local filesystem.
 ```js
 const decrypted = await decryptSops({
   path: "/path/to/config.enc.json",
-  secretKey: "AGE-SECRET-KEY-1qgdy...",
+  // secretKey optional - will auto-discover
 });
 ```
 
@@ -167,7 +264,7 @@ Decrypts a SOPS-encrypted file from a URL.
 ```js
 const decrypted = await decryptSops({
   url: "https://example.com/config.enc.json",
-  secretKey: "AGE-SECRET-KEY-1qgdy...",
+  secretKey: "AGE-SECRET-KEY-1qgdy...", // or auto-discover
 });
 ```
 
@@ -180,42 +277,59 @@ const sopsObject = {
   secret:
     "ENC[AES256_GCM,data:trrpgezXug4Dq9T/inwkMA==,iv:glPwxoY2UuHO91vlJRaqYtFkPY1VsWvkJtfkEKZJdns=,tag:v7DbOYl7C5gdQRdW6BVoLw==,type:str]",
   sops: {
-    kms: null,
-    gcp_kms: null,
-    azure_kv: null,
-    hc_vault: null,
-    age: [
-      {
-        recipient:
-          "age1je6kjhzuhdjy3fqptpttxjh5k8q46vygzlgtpuq3030c947pc5tqz9dqvr",
-        enc: "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsYVh6WTdzNnArL1E1RVVw\nZEoyU2hqZVZuVjR3bFJ2dlZaOGQ4VUVla1hVCll3MDZrY1VZeWtPNzVPUGNFWjBK\ncDZLVFZheU4wK0hBOTNmRFcwUkE4OFkKLS0tIHl3Y0x5Sk9lVDRCQkR3QzNzRWY4\ncFNPWFZqdEtyUmFhL3pLOHJvNlhuTTAKNLKVIFujPtmpYo/Oycit0JbcfPVN2TN5\nG9emUjK1XVOwkNda0olhEt4KAjSBV7dYt8luOL8VQeR33PadX7RK3A==\n-----END AGE ENCRYPTED FILE-----\n",
-      },
-    ],
-    lastmodified: "2024-12-25T09:03:17Z",
-    mac: "ENC[AES256_GCM,data:pjgkspXlmS1uFtR5yRZXcXISNEOk2/L4lN1zJoo49kgbABun2EwpZ2wfhPUDEDKn7kfmKuSOl4xQ/adUHVJh6bOHyQTf9lfH2BekCy828BIODowzk2tR5uiin8bB5q5VQfNJIaYEn3EWpGaOupEaNTZOyi5ML+WXB8s6w53Wg0w=,iv:wKEh9xSZ5RtsNdlRcEpYnbLKmUV6yitneJQhVt7qBSM=,tag:CmfHyYRe2/GVEexW5A8OWg==,type:str]",
-    pgp: null,
-    unencrypted_suffix: "_unencrypted",
-    version: "3.9.2",
+    // ... SOPS metadata
   },
 };
 
-// Assumes SOPS_AGE_KEY is set in the env
+// Auto-discovers keys from environment/config
 const decrypted = await decryptSops(sopsObject);
 ```
 
-### Options
+### `DecryptSopsOptions`
 
 The `decryptSops` function accepts the following options:
 
-- `secretKey`: The age secret key for decryption (required unless `SOPS_AGE_KEY` env var is set)
+- `secretKey`: The age secret key for decryption (optional - will auto-discover if not provided)
 - `fileType`: Optional file type ('env', 'json', or 'yaml'). Auto-detected if not specified
 - `keyPath`: Optional path to decrypt only a specific value
 - `path`: Path to local SOPS file (when using file-based decryption)
 - `url`: URL of SOPS file (when using URL-based decryption)
 
-## Environment Variables
+### Utility Functions
 
-- `SOPS_AGE_KEY`: If set, this environment variable will be used as the default secret key when none is provided in the options.
+#### `findAllAgeKeys()`
+
+Discovers all available age keys (including converted SSH keys) using SOPS logic:
+
+```js
+import { findAllAgeKeys } from "sops-age";
+
+const keys = await findAllAgeKeys();
+console.log("Available age keys:", keys);
+```
+
+#### `sshKeyToAge(keyContent, filePath)`
+
+Converts SSH private key content to age format:
+
+```js
+import { sshKeyToAge } from "sops-age";
+
+const sshKey = "-----BEGIN OPENSSH PRIVATE KEY-----\n...";
+const ageKey = sshKeyToAge(sshKey, "id_ed25519");
+// Returns: "AGE-SECRET-KEY-1..." or null for unsupported keys
+```
+
+#### `sshKeyFileToAge(filePath)`
+
+Converts SSH private key file to age format:
+
+```js
+import { sshKeyFileToAge } from "sops-age";
+
+const ageKey = await sshKeyFileToAge("~/.ssh/id_ed25519");
+// Returns: "AGE-SECRET-KEY-1..." or null
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@vitest/coverage-v8": "^3.0.6",
     "bun": "^1.2.3",
     "bun-types": "^1.2.3",
-    "console-fail-test": "^0.5.0",
     "deno": "^2.2.1",
     "esbuild-visualizer": "^0.7.0",
     "husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,12 @@
   },
   "dependencies": {
     "@noble/ciphers": "^1.2.1",
+    "@noble/hashes": "^1.8.0",
+    "@scure/base": "^1.2.5",
     "age-encryption": "^0.2.3",
     "dotenv": "^16.4.7",
     "lodash": "^4.17.21",
+    "sshpk": "^1.18.0",
     "yaml": "^2.7.0",
     "zod": "^3.24.2"
   },
@@ -64,6 +67,7 @@
     "@types/deno": "^2.2.0",
     "@types/lodash": "^4.17.15",
     "@types/node": "^22.13.5",
+    "@types/sshpk": "^1.17.4",
     "@vitest/coverage-v8": "^3.0.6",
     "bun": "^1.2.3",
     "bun-types": "^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@noble/ciphers':
         specifier: ^1.2.1
         version: 1.2.1
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
+      '@scure/base':
+        specifier: ^1.2.5
+        version: 1.2.5
       age-encryption:
         specifier: ^0.2.3
         version: 0.2.3
@@ -20,6 +26,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      sshpk:
+        specifier: ^1.18.0
+        version: 1.18.0
       yaml:
         specifier: ^2.7.0
         version: 2.7.0
@@ -42,6 +51,9 @@ importers:
       '@types/node':
         specifier: ^22.13.5
         version: 22.13.5
+      '@types/sshpk':
+        specifier: ^1.17.4
+        version: 1.17.4
       '@vitest/coverage-v8':
         specifier: ^3.0.6
         version: 3.0.6(vitest@3.0.6(@types/node@22.13.5))
@@ -735,6 +747,10 @@ packages:
     resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1027,8 +1043,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@scure/base@1.2.4':
-    resolution: {integrity: sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==}
+  '@scure/base@1.2.5':
+    resolution: {integrity: sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -1048,6 +1064,9 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@types/asn1@0.2.4':
+    resolution: {integrity: sha512-V91DSJ2l0h0gRhVP4oBfBzRBN9lAbPUkGDMCnwedqPKX2d84aAMc9CulOvxdw1f7DfEYx99afab+Rsm3e52jhA==}
 
   '@types/better-sqlite3@7.6.12':
     resolution: {integrity: sha512-fnQmj8lELIj7BSrZQAdBMHEHX8OZLYIHXqAKT1O7tDfLxaINzf00PMjw22r3N/xXh0w/sGHlO6SVaCQ2mj78lg==}
@@ -1072,6 +1091,9 @@ packages:
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+
+  '@types/sshpk@1.17.4':
+    resolution: {integrity: sha512-5gI/7eJn6wmkuIuFY8JZJ1g5b30H9K5U5vKrvOuYu+hoZLb2xcVEgxhYZ2Vhbs0w/ACyzyfkJq0hQtBfSCugjw==}
 
   '@types/ws@8.5.14':
     resolution: {integrity: sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==}
@@ -1188,6 +1210,13 @@ packages:
   as-table@1.0.55:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1216,6 +1245,9 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
@@ -1482,6 +1514,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
@@ -1586,6 +1622,9 @@ packages:
 
   easy-table@1.2.0:
     resolution: {integrity: sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==}
+
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
 
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
@@ -1811,6 +1850,9 @@ packages:
   get-uri@6.0.4:
     resolution: {integrity: sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==}
     engines: {node: '>= 14'}
+
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
 
   git-hooks-list@3.2.0:
     resolution: {integrity: sha512-ZHG9a1gEhUMX1TvGrLdyWb9kDopCBbTnI8z4JgRMYxsijWipgjSEYoPWqBuIB0DnRnvqlQSEeVmzpeuPm7NdFQ==}
@@ -2222,6 +2264,9 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
 
   jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
@@ -2945,6 +2990,11 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -3132,6 +3182,9 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -3937,6 +3990,8 @@ snapshots:
 
   '@noble/hashes@1.7.1': {}
 
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4166,7 +4221,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.34.8':
     optional: true
 
-  '@scure/base@1.2.4': {}
+  '@scure/base@1.2.5': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -4181,6 +4236,10 @@ snapshots:
       p-map: 4.0.0
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@types/asn1@0.2.4':
+    dependencies:
+      '@types/node': 22.13.5
 
   '@types/better-sqlite3@7.6.12':
     dependencies:
@@ -4201,6 +4260,11 @@ snapshots:
   '@types/parse-path@7.0.3': {}
 
   '@types/semver@7.5.8': {}
+
+  '@types/sshpk@1.17.4':
+    dependencies:
+      '@types/asn1': 0.2.4
+      '@types/node': 22.13.5
 
   '@types/ws@8.5.14':
     dependencies:
@@ -4274,8 +4338,8 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/base': 1.2.4
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.5
 
   agent-base@7.1.3: {}
 
@@ -4335,6 +4399,12 @@ snapshots:
     dependencies:
       printable-characters: 1.0.42
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
   assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
@@ -4359,6 +4429,10 @@ snapshots:
   balanced-match@1.0.2: {}
 
   basic-ftp@5.0.5: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   before-after-hook@3.0.2: {}
 
@@ -4650,6 +4724,10 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+
   data-uri-to-buffer@2.0.2: {}
 
   data-uri-to-buffer@6.0.2: {}
@@ -4752,6 +4830,11 @@ snapshots:
       ansi-regex: 5.0.1
     optionalDependencies:
       wcwidth: 1.0.1
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
 
   emoji-regex@10.4.0: {}
 
@@ -5090,6 +5173,10 @@ snapshots:
       debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
+
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
 
   git-hooks-list@3.2.0: {}
 
@@ -5491,6 +5578,8 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsbn@0.1.1: {}
 
   jsbn@1.1.0: {}
 
@@ -6303,6 +6392,18 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+
   stackback@0.0.2: {}
 
   stacktracey@2.1.8:
@@ -6494,6 +6595,8 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tweetnacl@0.14.5: {}
 
   type-fest@0.21.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       bun-types:
         specifier: ^1.2.3
         version: 1.2.3
-      console-fail-test:
-        specifier: ^0.5.0
-        version: 0.5.0
       deno:
         specifier: ^2.2.1
         version: 2.2.1
@@ -1421,10 +1418,6 @@ packages:
   consola@3.4.0:
     resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  console-fail-test@0.5.0:
-    resolution: {integrity: sha512-nghkQcJ9DJMYtdN1L/ZNu1GvnLMo38DTneWX23+WbIdvjuVkbcshGFxgIG5LbI9j/th4dgwUc0Hiwtq85VWb/Q==}
-    engines: {node: '>=18'}
 
   conventional-changelog-angular@8.0.0:
     resolution: {integrity: sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==}
@@ -4618,8 +4611,6 @@ snapshots:
       xdg-basedir: 5.1.0
 
   consola@3.4.0: {}
-
-  console-fail-test@0.5.0: {}
 
   conventional-changelog-angular@8.0.0:
     dependencies:

--- a/src/age-key.ts
+++ b/src/age-key.ts
@@ -24,9 +24,8 @@ function parseX25519KeysFromString(
     if (trimmedLine === "" || trimmedLine.startsWith("#")) {
       continue;
     }
-    if (
-      trimmedLine.toUpperCase().startsWith(X25519_PRIVATE_KEY_HRP.toUpperCase())
-    ) {
+
+    if (trimmedLine.toUpperCase().startsWith(X25519_PRIVATE_KEY_HRP)) {
       keyStrings.push(trimmedLine);
     } else if (trimmedLine.startsWith("AGE-PLUGIN-")) {
       console.warn(
@@ -44,7 +43,6 @@ function parseX25519KeysFromString(
   return keyStrings;
 }
 
-// getUserConfigDir function (remains the same as your original)
 async function getUserConfigDir(): Promise<string> {
   if (platform() === "darwin") {
     const xdgConfigHome = process.env.XDG_CONFIG_HOME;
@@ -77,7 +75,6 @@ async function getUserConfigDir(): Promise<string> {
  * - Looks in the sops/age/keys.txt config dir for age keys.
  */
 export async function findAllAgeKeys(): Promise<string[]> {
-  // Track if any potential key source is identified
   let foundKeySource = false;
 
   // 1. SSH Keys (converted to X25519 Bech32 strings)

--- a/src/age-key.ts
+++ b/src/age-key.ts
@@ -1,0 +1,251 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { platform, homedir } from "node:os";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { X25519_PRIVATE_KEY_HRP } from "./age.js";
+import { sshKeyFileToAge } from "./ssh-to-age.js";
+
+const execAsync = promisify(exec);
+const SOPS_AGE_KEY_USER_CONFIG_PATH = "sops/age/keys.txt";
+
+/**
+ * Parses content (e.g., from keys.txt or env var) for age keys (X25519 Bech32 key strings).
+ * Returns an array of valid X25519 Bech32 private key strings.
+ */
+function parseX25519KeysFromString(
+  content: string,
+  sourceName: string,
+): string[] {
+  const keyStrings: string[] = [];
+  const lines = content.split("\n");
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+    if (trimmedLine === "" || trimmedLine.startsWith("#")) {
+      continue;
+    }
+    if (
+      trimmedLine.toUpperCase().startsWith(X25519_PRIVATE_KEY_HRP.toUpperCase())
+    ) {
+      keyStrings.push(trimmedLine);
+    } else if (trimmedLine.startsWith("AGE-PLUGIN-")) {
+      console.warn(
+        `AGE plugin keys are not supported: ${trimmedLine.substring(0, 30)}... from ${sourceName}`,
+      );
+    } else if (trimmedLine.length > 0) {
+      console.warn(
+        `Skipping unrecognized line in ${sourceName}: ${trimmedLine.substring(
+          0,
+          30,
+        )}...`,
+      );
+    }
+  }
+  return keyStrings;
+}
+
+// getUserConfigDir function (remains the same as your original)
+async function getUserConfigDir(): Promise<string> {
+  if (platform() === "darwin") {
+    const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+    if (xdgConfigHome && xdgConfigHome.trim() !== "") return xdgConfigHome;
+  }
+  switch (platform()) {
+    case "win32":
+      const appData = process.env.APPDATA;
+      if (!appData) throw new Error("APPDATA env var not set");
+      return appData;
+    case "darwin":
+      return join(homedir(), "Library", "Application Support");
+    default:
+      const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+      if (xdgConfigHome && xdgConfigHome.trim() !== "") return xdgConfigHome;
+      return join(homedir(), ".config");
+  }
+}
+
+/**
+ * Finds all age secret keys (X25519 strings) according to SOPS rules, see:
+ * https://github.com/getsops/sops?tab=readme-ov-file#encrypting-using-age
+ *
+ * - Converts SSH keys (Ed25519, RSA) to X25519 format using either
+ * SOPS_AGE_SSH_PRIVATE_KEY_FILE or .ssh/id_ed25519, .ssh/id_rsa.
+ *
+ * - Uses SOPS_AGE_KEY or SOPS_AGE_KEY_FILE or SOPS_AGE_KEY_CMD to get an
+ * age key or keys.
+ *
+ * - Looks in the sops/age/keys.txt config dir for age keys.
+ */
+export async function findAllAgeKeys(): Promise<string[]> {
+  // Track if any potential key source is identified
+  let foundKeySource = false;
+
+  // 1. SSH Keys (converted to X25519 Bech32 strings)
+  const convertedSshKeys: string[] = [];
+  const sshKeyFilePathEnv = process.env.SOPS_AGE_SSH_PRIVATE_KEY_FILE;
+  if (sshKeyFilePathEnv) {
+    try {
+      const x25519KeyStr = await sshKeyFileToAge(sshKeyFilePathEnv);
+      if (x25519KeyStr) {
+        convertedSshKeys.push(x25519KeyStr);
+        foundKeySource = true;
+      }
+    } catch (error) {
+      throw new Error(
+        `Error processing SOPS_AGE_SSH_PRIVATE_KEY_FILE (${sshKeyFilePathEnv}): ${
+          (error as Error).message
+        }`,
+        { cause: error },
+      );
+    }
+  } else {
+    const userHomeDir = homedir();
+    if (userHomeDir) {
+      const defaultSshPaths = [
+        join(userHomeDir, ".ssh", "id_ed25519"),
+        join(userHomeDir, ".ssh", "id_rsa"),
+      ];
+      for (const sshPath of defaultSshPaths) {
+        // NOTE: if an SSH key was already loaded (from env var), SOPS doesn't
+        // bother looking for default SSH keys.
+        if (foundKeySource && convertedSshKeys.length > 0) {
+          break;
+        }
+
+        try {
+          const x25519KeyStr = await sshKeyFileToAge(sshPath);
+          if (x25519KeyStr) {
+            convertedSshKeys.push(x25519KeyStr);
+            foundKeySource = true;
+            // SOPS uses the first default SSH key found
+            break;
+          }
+        } catch (error: any) {
+          if (error.code === "ENOENT") {
+            // Ignore default ssh keys not being found
+            continue;
+          }
+
+          throw new Error(
+            `Error processing default SSH key file (${sshPath}): ${
+              (error as Error).message
+            }`,
+            { cause: error },
+          );
+        }
+      }
+    }
+  }
+
+  const sopsAgeKeyContents: { sourceName: string; content: string }[] = [];
+
+  // 2. SOPS_AGE_KEY environment variable
+  const ageKeyEnv = process.env.SOPS_AGE_KEY;
+  if (ageKeyEnv) {
+    sopsAgeKeyContents.push({
+      sourceName: "SOPS_AGE_KEY (environment variable)",
+      content: ageKeyEnv,
+    });
+    foundKeySource = true;
+  }
+
+  // 3. SOPS_AGE_KEY_FILE environment variable
+  const ageKeyFileEnv = process.env.SOPS_AGE_KEY_FILE;
+  if (ageKeyFileEnv) {
+    try {
+      const content = await readFile(ageKeyFileEnv, "utf-8");
+      sopsAgeKeyContents.push({
+        sourceName: `SOPS_AGE_KEY_FILE (${ageKeyFileEnv})`,
+        content,
+      });
+      foundKeySource = true;
+    } catch (error) {
+      throw new Error(
+        `Failed to read SOPS_AGE_KEY_FILE (${ageKeyFileEnv}): ${
+          (error as Error).message
+        }`,
+        { cause: error },
+      );
+    }
+  }
+
+  // 4. SOPS_AGE_KEY_CMD environment variable
+  const ageKeyCmdEnv = process.env.SOPS_AGE_KEY_CMD;
+  if (ageKeyCmdEnv) {
+    try {
+      const { stdout } = await execAsync(ageKeyCmdEnv);
+      sopsAgeKeyContents.push({
+        sourceName: `SOPS_AGE_KEY_CMD output (${ageKeyCmdEnv})`,
+        content: stdout,
+      });
+      foundKeySource = true;
+    } catch (error) {
+      throw new Error(
+        `Failed to execute SOPS_AGE_KEY_CMD (${ageKeyCmdEnv}): ${
+          (error as Error).message
+        }`,
+        { cause: error },
+      );
+    }
+  }
+
+  // 5. Default user config file (sops/age/keys.txt)
+  let userConfigDirPath: string | null = null;
+  try {
+    userConfigDirPath = await getUserConfigDir();
+  } catch (error) {
+    if (!foundKeySource && convertedSshKeys.length === 0) {
+      throw new Error(
+        `User config directory not determinable, and no other key sources found: ${
+          (error as Error).message
+        }`,
+      );
+    }
+  }
+
+  if (userConfigDirPath) {
+    const sopsKeysFilePath = join(
+      userConfigDirPath,
+      SOPS_AGE_KEY_USER_CONFIG_PATH,
+    );
+    try {
+      const content = await readFile(sopsKeysFilePath, "utf-8");
+      sopsAgeKeyContents.push({
+        sourceName: `Default keys.txt (${sopsKeysFilePath})`,
+        content,
+      });
+      foundKeySource = true;
+    } catch (error: any) {
+      if (error.code === "ENOENT") {
+        if (
+          !foundKeySource &&
+          convertedSshKeys.length === 0 && // No SSH keys found
+          sopsAgeKeyContents.length === 0 // No env/cmd keys found
+        ) {
+          throw new Error(
+            `Default sops keys file (${sopsKeysFilePath}) not found, and no other key sources specified.`,
+            { cause: error },
+          );
+        }
+      } else {
+        throw new Error(
+          `Failed to read default sops keys file (${sopsKeysFilePath}): ${error.message}`,
+          { cause: error },
+        );
+      }
+    }
+  }
+
+  // Parse X25519 key strings from the collected sops age key contents
+  const sopsKeys = sopsAgeKeyContents
+    .map((sopsAgeKeyContent) => {
+      const keysFromContent = parseX25519KeysFromString(
+        sopsAgeKeyContent.content,
+        sopsAgeKeyContent.sourceName,
+      );
+      return keysFromContent;
+    })
+    .flat();
+
+  return [...new Set([...sopsKeys, ...convertedSshKeys])];
+}

--- a/src/age.ts
+++ b/src/age.ts
@@ -1,5 +1,7 @@
 import * as age from "age-encryption";
 
+export const X25519_PRIVATE_KEY_HRP = "AGE-SECRET-KEY-1";
+
 export async function getPublicAgeKey(privateAgeKey: string) {
   return age.identityToRecipient(privateAgeKey);
 }

--- a/src/decrypt.ts
+++ b/src/decrypt.ts
@@ -6,6 +6,7 @@ import type { SOPS } from "./sops-file.js";
 import { decryptAgeEncryptionKey, getPublicAgeKey } from "./age.js";
 import { type EncryptedData, decryptAesGcm } from "./cipher-noble.js";
 import { getEnvVar } from "./runtime.js";
+import { findAllAgeKeys } from "./age-key.js";
 
 export type SOPSDataType = "bool" | "bytes" | "float" | "int" | "str";
 
@@ -69,15 +70,41 @@ function parse(value: string): ParsedEncryptedData {
   }
 }
 
-async function getSopsEncryptionKeyForRecipient(sops: SOPS, secretKey: string) {
-  const pubKey = await getPublicAgeKey(secretKey);
+/**
+ * Attempts to find a matching age recipient and decrypt the encryption key
+ * using all available secret keys until one works.
+ */
+async function getSopsEncryptionKey(
+  sops: SOPS,
+  secretKeys: string[],
+): Promise<Uint8Array> {
+  const errors: string[] = [];
 
-  const recipient = sops.sops.age.find((config) => config.recipient === pubKey);
-  if (!recipient) {
-    throw new Error("no matching recipient found in age config");
+  for (const secretKey of secretKeys) {
+    try {
+      const pubKey = await getPublicAgeKey(secretKey);
+      const recipient = sops.sops.age.find(
+        (config) => config.recipient === pubKey,
+      );
+
+      if (!recipient) {
+        errors.push(`No matching recipient found for key: ${pubKey}`);
+        continue;
+      }
+
+      return await decryptAgeEncryptionKey(recipient.enc, secretKey);
+    } catch (error) {
+      errors.push(
+        `Failed to decrypt with key ${secretKey.substring(0, 20)}...: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 
-  return decryptAgeEncryptionKey(recipient.enc, secretKey);
+  throw new Error(
+    `Failed to decrypt with any available age keys. Errors:\n${errors.join("\n")}`,
+  );
 }
 
 /**
@@ -160,9 +187,8 @@ export interface DecryptOptions {
    */
   keyPath?: string;
 
-  /**
-   * The secret key (e.g., AGE key) to use when decrypting.
-   * If not specified the `SOPS_AGE_KEY` env var will be used, if available.
+  /* The secret key (e.g., AGE key) to use when decrypting.
+   * If not specified, all available keys will be discovered and tried.
    */
   secretKey?: string;
 }
@@ -170,8 +196,13 @@ export interface DecryptOptions {
 /**
  * Decrypts a SOPS-encrypted data structure using an AGE key.
  *
- * If a keyPath is provided, only that specific value will be decrypted and returned.
- * Otherwise, the entire data structure (excluding SOPS metadata) will be decrypted.
+ * If no secretKey is provided, all available age keys will be discovered
+ * using the same logic as SOPS:
+ * - SSH keys (converted to age format)
+ * - SOPS_AGE_KEY environment variable
+ * - SOPS_AGE_KEY_FILE environment variable
+ * - SOPS_AGE_KEY_CMD environment variable
+ * - Default config file (~/.config/sops/age/keys.txt)
  *
  * @param sops - The SOPS data structure containing encrypted values and metadata
  * @param options - Configuration options for decryption
@@ -180,15 +211,41 @@ export interface DecryptOptions {
  * @returns The decrypted value (if keyPath provided) or object with all values decrypted
  */
 export async function decrypt(sops: SOPS, options: DecryptOptions) {
-  const keyPath = options.keyPath;
-  const secretKey = options.secretKey ?? getEnvVar("SOPS_AGE_KEY");
-  if (!secretKey) {
-    throw new Error(
-      "A secretKey is required to decrypt. Set one on options or via the SOPS_AGE_KEY environment variable",
-    );
+  const { keyPath, secretKey } = options;
+
+  // Determine which secret keys to use
+  let secretKeys: string[];
+  if (secretKey) {
+    // Use the explicitly provided key
+    secretKeys = [secretKey];
+  } else {
+    // Check for SOPS_AGE_KEY environment variable first (for backwards compatibility)
+    const envKey = getEnvVar("SOPS_AGE_KEY");
+    if (envKey) {
+      secretKeys = [envKey];
+    } else {
+      // Discover all available keys using SOPS logic
+      try {
+        secretKeys = await findAllAgeKeys();
+      } catch (error) {
+        throw new Error(
+          `Failed to find age keys: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+
+      if (secretKeys.length === 0) {
+        throw new Error(
+          "No age keys found. Provide a secretKey option or set up age keys " +
+            "via environment variables, SSH keys, or the default config file.",
+        );
+      }
+    }
   }
 
-  const decryptionKey = await getSopsEncryptionKeyForRecipient(sops, secretKey);
+  // Try to decrypt the SOPS encryption key with available secret keys
+  const decryptionKey = await getSopsEncryptionKey(sops, secretKeys);
 
   // If we have a path to a specific key, only decrypt that
   if (keyPath) {

--- a/src/decrypt.ts
+++ b/src/decrypt.ts
@@ -219,28 +219,22 @@ export async function decrypt(sops: SOPS, options: DecryptOptions) {
     // Use the explicitly provided key
     secretKeys = [secretKey];
   } else {
-    // Check for SOPS_AGE_KEY environment variable first (for backwards compatibility)
-    const envKey = getEnvVar("SOPS_AGE_KEY");
-    if (envKey) {
-      secretKeys = [envKey];
-    } else {
-      // Discover all available keys using SOPS logic
-      try {
-        secretKeys = await findAllAgeKeys();
-      } catch (error) {
-        throw new Error(
-          `Failed to find age keys: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
+    // Discover all available keys using SOPS logic
+    try {
+      secretKeys = await findAllAgeKeys();
+    } catch (error) {
+      throw new Error(
+        `Failed to find age keys: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
 
-      if (secretKeys.length === 0) {
-        throw new Error(
-          "No age keys found. Provide a secretKey option or set up age keys " +
-            "via environment variables, SSH keys, or the default config file.",
-        );
-      }
+    if (secretKeys.length === 0) {
+      throw new Error(
+        "No age keys found. Provide a secretKey option or set age keys via " +
+          "environment variables, SSH keys, or the default sops keys.txt config file.",
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,7 @@ export async function decryptSops(
 }
 
 /**
- * Useful utilities for finding and converting to age keys
+ * Useful utilities for discovering age keys and converting SSH keys to age keys
  */
 export { findAllAgeKeys } from "./age-key.js";
 export { sshKeyToAge, sshKeyFileToAge } from "./ssh-to-age.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,3 +141,9 @@ export async function decryptSops(
     "Invalid options: when no input given, you must specify one of `path` or `url`",
   );
 }
+
+/**
+ * Useful utilities for finding and converting to age keys
+ */
+export { findAllAgeKeys } from "./age-key.js";
+export { sshKeyToAge, sshKeyFileToAge } from "./ssh-to-age.js";

--- a/src/ssh-to-age.ts
+++ b/src/ssh-to-age.ts
@@ -1,0 +1,130 @@
+import { sha256, sha512 } from "@noble/hashes/sha2";
+import { bech32 } from "@scure/base";
+import * as sshpk from "sshpk";
+import { readFile } from "node:fs/promises";
+
+function clampX25519PrivateKey(key: Uint8Array): void {
+  if (key.length !== 32) {
+    throw new Error("X25519 private key must be 32 bytes for clamping.");
+  }
+  key[0] &= 248;
+  key[31] &= 127;
+  key[31] |= 64;
+}
+
+function encodeX25519Bech32PrivateKey(privateKeyBytes: Uint8Array): string {
+  if (privateKeyBytes.length !== 32) {
+    throw new Error("X25519 private key must be 32 bytes for Bech32 encoding.");
+  }
+  const encoded = bech32.encode(
+    "AGE-SECRET-KEY-",
+    bech32.toWords(privateKeyBytes),
+  );
+  return encoded.toUpperCase();
+}
+
+function convertEd25519SeedToX25519PrivateKey(
+  ed25519Seed: Uint8Array,
+): Uint8Array {
+  if (ed25519Seed.length !== 32) {
+    throw new Error("ed25519 seed must be 32 bytes.");
+  }
+  const hashedSeed = sha512(ed25519Seed);
+  // The X25519 private key is the first 32 bytes of the SHA-512 hash of the Ed25519 seed.
+  const x25519Sk = hashedSeed.slice(0, 32);
+  return x25519Sk;
+}
+
+function convertRsaPublicKeyToX25519PrivateKey(
+  rsaN: Uint8Array,
+  rsaE: Uint8Array,
+): Uint8Array {
+  const hasher = sha256.create();
+  hasher.update(rsaN);
+  hasher.update(rsaE);
+  const x25519Sk = hasher.digest();
+  clampX25519PrivateKey(x25519Sk);
+  return x25519Sk;
+}
+
+/**
+ * Parses SSH private key content, converts to an X25519 Bech32 private key string.
+ * Returns the Bech32 string or null if the key is unsupported or file is empty.
+ * Throws an error if parsing/conversion fails for a supported type.
+ */
+export function sshKeyToAge(
+  keyFileContent: string,
+  filePathForErrorMsg: string,
+): string | null {
+  try {
+    if (keyFileContent.trim() === "") {
+      // TOOD: throw or return null?
+      throw new Error("SSH key should not be empty");
+    }
+
+    const sshPk = sshpk.parsePrivateKey(keyFileContent, "auto", {
+      filename: filePathForErrorMsg,
+    });
+    let x25519SkBytes: Uint8Array;
+
+    if (sshPk.type === "ed25519") {
+      // sshpk provides the 32-byte private seed directly as part "k".
+      // Part "A" is the 32-byte public key.
+      const seedPart = sshPk.parts.find(
+        (part) => part.name === "k" && part.data && part.data.length === 32,
+      );
+
+      if (!seedPart || !seedPart.data) {
+        console.error(
+          `Failed to find 32-byte "k" part (seed) for Ed25519 key. SSHPK Parts for ${filePathForErrorMsg}:`,
+        );
+        sshPk.parts.forEach((part, index) => {
+          console.error(
+            `  Part ${index}: Name: "${part.name}", Type: ${typeof part.data}, Length: ${part.data?.length}`,
+          );
+        });
+        throw new Error(
+          `Could not extract 32-byte seed (part "k") from Ed25519 key in ${filePathForErrorMsg}.`,
+        );
+      }
+      const ed25519Seed = Uint8Array.from(seedPart.data);
+      x25519SkBytes = convertEd25519SeedToX25519PrivateKey(ed25519Seed);
+    } else if (sshPk.type === "rsa") {
+      // Access RSA components (N, E) from the `parts` array
+      const rsaNPart = sshPk.parts.find((part) => part.name === "n");
+      const rsaEPart = sshPk.parts.find((part) => part.name === "e");
+
+      if (!rsaNPart || !rsaEPart || !rsaNPart.data || !rsaEPart.data) {
+        throw new Error(
+          `Could not extract N or E (modulus or public exponent) from RSA key in ${filePathForErrorMsg}.`,
+        );
+      }
+      const rsaN = Uint8Array.from(rsaNPart.data);
+      const rsaE = Uint8Array.from(rsaEPart.data);
+      x25519SkBytes = convertRsaPublicKeyToX25519PrivateKey(rsaN, rsaE);
+    } else {
+      console.warn(
+        `Unsupported SSH key type "${sshPk.type}" for age conversion in ${filePathForErrorMsg}. Skipping.`,
+      );
+      return null;
+    }
+    return encodeX25519Bech32PrivateKey(x25519SkBytes);
+  } catch (error: any) {
+    throw new Error(
+      `Failed to parse/convert SSH key from ${filePathForErrorMsg}: ${
+        error.message || error
+      }`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * Reads an SSH private key file, parses, and converts to age (X25519 Bech32 string).
+ */
+export async function sshKeyFileToAge(
+  filePath: string,
+): Promise<string | null> {
+  const content = await readFile(filePath, "utf-8");
+  return sshKeyToAge(content, filePath);
+}

--- a/src/ssh-to-age.ts
+++ b/src/ssh-to-age.ts
@@ -57,9 +57,9 @@ export function sshKeyToAge(
   filePathForErrorMsg: string,
 ): string | null {
   try {
+    // Empty file? Nothing to parse.
     if (keyFileContent.trim() === "") {
-      // TOOD: throw or return null?
-      throw new Error("SSH key should not be empty");
+      return null;
     }
 
     const sshPk = sshpk.parsePrivateKey(keyFileContent, "auto", {

--- a/tests/unit/age-key.test.ts
+++ b/tests/unit/age-key.test.ts
@@ -1,0 +1,938 @@
+import {
+  describe,
+  expect,
+  test,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  afterAll,
+} from "vitest";
+import { findAllAgeKeys } from "../../src/age-key.js";
+import { X25519_PRIVATE_KEY_HRP } from "../../src/age.js";
+import { sshKeyToAge } from "../../src/ssh-to-age.js";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+const DUMMY_ED25519_PRIVATE_KEY_CONTENT = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACC6AomzbioPu1vf0niUWVCclpKqTmymaK6YaQA3zNbeZwAAAJjJ8P5tyfD+
+bQAAAAtzc2gtZWQyNTUxOQAAACC6AomzbioPu1vf0niUWVCclpKqTmymaK6YaQA3zNbeZw
+AAAEDejh/ezX+crUvh/3ksDn2IBJUEDaQcAzNvG+jrNgHkN7oCibNuKg+7W9/SeJRZUJyW
+kqpObKZorphpADfM1t5nAAAAD3Rlc3RrZXlAdGVzdGluZwECAwQFBg==
+-----END OPENSSH PRIVATE KEY-----`;
+
+// ./ssh-to-age -private-key -i ./dummy_ed25519_for_test
+const EXPECTED_AGE_KEY_FROM_DUMMY_ED25519 = `AGE-SECRET-KEY-1MCRYZAW398UH47D5EYC6GECNUJJ4FFE8A7HQEWNXXHEXW4ULEA6Q6EV8JY`;
+
+const DUMMY_RSA_PRIVATE_KEY_CONTENT = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
+NhAAAAAwEAAQAAAQEAxHkZNWfcZUqg5LywB4KB//g6+iug7cfuXYgIUb88rcej582oRtJw
+fy+eqTsKAhYJZnl+a7W3DUa32E6mV34lXqfi6caIIBYQTpkmSircYb18Og3OcPYHAqnxKl
+iXiCt98EFiPylrFL3wioPaKU6jrI3JecePItnPc8f5rb4P3eyjkHDjbRCIJUPLQy3kEWfr
+oilDeblBvd0qrLt7uk9oBVcJj8hWdosOl6llBDkgzlNmMsvaxEGJ44HuLk/VsYcp/HhLya
+Cq6ImpZ+2iDNNgzHEV72HDdHhR3xeV9glYYYEW3fpcf8mqHdZ/NaJ7JyIpASBCpfWKlBfV
+zpvRF5UNoQAAA8jzoFQ686BUOgAAAAdzc2gtcnNhAAABAQDEeRk1Z9xlSqDkvLAHgoH/+D
+r6K6Dtx+5diAhRvzytx6PnzahG0nB/L56pOwoCFglmeX5rtbcNRrfYTqZXfiVep+Lpxogg
+FhBOmSZKKtxhvXw6Dc5w9gcCqfEqWJeIK33wQWI/KWsUvfCKg9opTqOsjcl5x48i2c9zx/
+mtvg/d7KOQcONtEIglQ8tDLeQRZ+uiKUN5uUG93Sqsu3u6T2gFVwmPyFZ2iw6XqWUEOSDO
+U2Yyy9rEQYnjge4uT9Wxhyn8eEvJoKroialn7aIM02DMcRXvYcN0eFHfF5X2CVhhgRbd+l
+x/yaod1n81onsnIikBIEKl9YqUF9XOm9EXlQ2hAAAAAwEAAQAAAQAm6/KRgOTJcDJVfgfF
+RRZp1gwg+TmlQWE4SDWVtDPaHV2cE0LN3OyKVa2xys9dwG3WTiU8Q0BjMepDwLj1Rjky+k
+FanIjlClnqqC5MrRcBid8tRQTrneGfpnjvMaO7Rxpo2RsUdikPb91SI3K5kimcim4qYN07
+Qzj0r94HjEpqZRjaLO7reAsR0/SOegDMY1iTuLuTX1MM04HeKhnB4/Ob8VNJuQtCUMFSQq
+Tnki7f2Jwh4DreAqu0ZCi/Vk9jIpv9peDNll6Nohk5ogoBQxzus6IccOU7lZ9J5ssuJ0na
+TfMyV+St3/9bNdNuX9Wdoi+ovE8X4j+97TTyL4wrY83RAAAAgAdjR+LBhDwFEZKhEBK2SW
+hRvSmPGe1/gD27CnRljPhyR8DkFD/HYUTqCCi9JrsnU+8PMWB2BHUtjva1Z6oMYbZoZBPo
+k09+cqVPXq6uY4SVoejebe54PkqMBQ3h7wBeliKyUMo/CM+whiFWnF43KPeuI/pVgeDfrj
+962248KHfeAAAAgQDhPLWME0OSei5gBf+RIupLlYumBPOn5Sd50xj1OtG5m/XHjwAu/QvQ
+/LsK8+PA5TyArVhxaD2IFyCgKrDv66mJo6NYpI0+mvrNgy+0Z7DifuEe6s/2rYnwrtRzRN
+ybn1pFkNQKUw+oGnhDz7V9y0N/PZI1kAmC4edckWBkwl92TQAAAIEA306rIY1JCPSDaybP
+QfJVOTfU5hNn6XcYHB9/JxUUAI8uSDGO0HimHLcRyC9jRGIrL9lTDyoFCblLsOP94pHegt
+0GRosN8Eu7KxYwjoTfpSvGLHPRokFiJaY22XrXmDB6bqBRnxl89MItLjPqWP/UYl3AQbqo
+79Bg9oAgOZRoBqUAAAAQdGVzdC1yc2FAdGVzdGluZwECAw==
+-----END OPENSSH PRIVATE KEY-----
+`;
+
+const MOCK_AGE_KEY_1 = `${X25519_PRIVATE_KEY_HRP}TESTKEY1ABCDEFGHIJKLMNOPQRSTUVWXYZ012345`;
+const MOCK_AGE_KEY_2 = `${X25519_PRIVATE_KEY_HRP}TESTKEY2ABCDEFGHIJKLMNOPQRSTUVWXYZ543210`;
+
+let tempRootDir: string;
+let mockHomeDir: string;
+let mockXdgConfigHome: string;
+let mockAppDataDir: string;
+
+let clearEnv: () => void;
+
+beforeEach(() => {
+  tempRootDir = mkdtempSync(join(tmpdir(), "sops-age-tests-"));
+  // Define mock home/config directories within the temp root
+  mockHomeDir = join(tempRootDir, "userhome");
+  // Simulates Linux/XDG structure
+  mockXdgConfigHome = join(mockHomeDir, ".config");
+  // Simulates Windows structure
+  mockAppDataDir = join(mockHomeDir, "AppData", "Roaming");
+
+  mkdirSync(mockHomeDir, { recursive: true });
+  mkdirSync(mockXdgConfigHome, { recursive: true });
+  mkdirSync(mockAppDataDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (clearEnv) {
+    clearEnv();
+  }
+  if (tempRootDir) {
+    rmSync(tempRootDir, { recursive: true, force: true });
+  }
+});
+
+const setEnvVars = (vars: Record<string, string | undefined>) => {
+  const originalEnv: Record<string, string | undefined> = {};
+  Object.keys(vars).forEach((key) => {
+    originalEnv[key] = process.env[key];
+  });
+  if (process.env.NODE_ENV) {
+    originalEnv.NODE_ENV = process.env.NODE_ENV;
+  }
+
+  for (const key in vars) {
+    if (vars[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = vars[key];
+    }
+  }
+  clearEnv = () => {
+    for (const key in originalEnv) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+    if (originalEnv.NODE_ENV) {
+      process.env.NODE_ENV = originalEnv.NODE_ENV;
+    } else {
+      delete process.env.NODE_ENV;
+    }
+  };
+};
+
+function ensureTargetDirectories() {
+  // Ensure the target directories for default keys exist but are empty
+  mkdirSync(join(mockHomeDir, ".ssh"), { recursive: true });
+  mkdirSync(join(mockXdgConfigHome, "sops", "age"), { recursive: true });
+  mkdirSync(join(mockAppDataDir, "sops", "age"), { recursive: true });
+}
+
+describe("SSH Key Conversion Tests", () => {
+  test("should convert Ed25519 SSH private key to age format", () => {
+    const ageKey = sshKeyToAge(
+      DUMMY_ED25519_PRIVATE_KEY_CONTENT,
+      "test-ed25519",
+    );
+    expect(ageKey).toBe(EXPECTED_AGE_KEY_FROM_DUMMY_ED25519);
+  });
+
+  test("should convert RSA SSH private key to a valid age format", () => {
+    const ageKey = sshKeyToAge(DUMMY_RSA_PRIVATE_KEY_CONTENT, "test-rsa");
+    expect(ageKey).not.toBeNull();
+    expect(ageKey).toMatch(/^AGE-SECRET-KEY-1[A-Z0-9]+$/);
+  });
+
+  test("should load RSA key from SOPS_AGE_SSH_PRIVATE_KEY_FILE", async () => {
+    const sshKeyPath = join(tempRootDir, "dummy_rsa_for_env.key");
+    writeFileSync(sshKeyPath, DUMMY_RSA_PRIVATE_KEY_CONTENT);
+    setEnvVars({
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: sshKeyPath,
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: mockAppDataDir,
+    });
+    ensureTargetDirectories();
+
+    const keys = await findAllAgeKeys();
+    keys.forEach((key) => {
+      expect(key).toMatch(/^AGE-SECRET-KEY-1[A-Z0-9]+$/);
+    });
+  });
+
+  test("should load RSA key from default .ssh/id_rsa", async () => {
+    setEnvVars({
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: mockAppDataDir,
+      SOPS_AGE_KEY: undefined,
+      SOPS_AGE_KEY_FILE: undefined,
+      SOPS_AGE_KEY_CMD: undefined,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+    });
+
+    const defaultSshDir = join(mockHomeDir, ".ssh");
+    mkdirSync(defaultSshDir, { recursive: true });
+    const defaultSshKeyPath = join(defaultSshDir, "id_rsa");
+    writeFileSync(defaultSshKeyPath, DUMMY_RSA_PRIVATE_KEY_CONTENT);
+
+    mkdirSync(join(mockXdgConfigHome, "sops", "age"), { recursive: true });
+    mkdirSync(join(mockAppDataDir, "sops", "age"), { recursive: true });
+
+    const keys = await findAllAgeKeys();
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toMatch(/^AGE-SECRET-KEY-1[A-Z0-9]+$/);
+  });
+});
+
+describe("Edge Cases and Error Handling", () => {
+  test("should handle unsupported SSH key types gracefully", () => {
+    // ECDSA key (not supported by either ssh-to-age or SOPS)
+    const ecdsaKey = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS
+1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQTi+HXotolCdcCT/1rrsISB7eb47QhH
+FjkCAGAb9vebevw/J2eHa0LB0z16RgMWHbrOse3fNh1Z8zwCl7Sw4uRtAAAAsDNVff8zVX
+3/AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBOL4dei2iUJ1wJP/
+WuuwhIHt5vjtCEcWOQIAYBv295t6/D8nZ4drQsHTPXpGAxYdus6x7d82HVnzPAKXtLDi5G
+0AAAAgZzg1O7cXWxCG0sKXcsJG6/M7NWwuMWVREerv3j1K00QAAAASdGVzdC1lY2RzYUB0
+ZXN0aW5nAQIDBAUG
+-----END OPENSSH PRIVATE KEY-----
+`;
+
+    const result = sshKeyToAge(ecdsaKey, "test-ecdsa");
+    expect(result).toBeNull();
+  });
+
+  test("should handle malformed SSH keys", () => {
+    const malformedKey = "not-a-valid-ssh-key";
+    expect(() => sshKeyToAge(malformedKey, "test-malformed")).toThrow();
+  });
+
+  test("should handle empty SSH key content", () => {
+    expect(() => sshKeyToAge("", "test-empty")).toThrow(
+      "SSH key should not be empty",
+    );
+    expect(() => sshKeyToAge("   \n  ", "test-whitespace")).toThrow(
+      "SSH key should not be empty",
+    );
+  });
+});
+
+describe("Key Source Priority and Precedence", () => {
+  test("should prioritize SOPS_AGE_SSH_PRIVATE_KEY_FILE over default SSH keys", async () => {
+    const sshKeyPath = join(tempRootDir, "priority_test.key");
+    writeFileSync(sshKeyPath, DUMMY_ED25519_PRIVATE_KEY_CONTENT);
+
+    setEnvVars({
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: sshKeyPath,
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: mockAppDataDir,
+    });
+
+    // Create a different SSH key in the default location
+    const defaultSshDir = join(mockHomeDir, ".ssh");
+    mkdirSync(defaultSshDir, { recursive: true });
+    writeFileSync(
+      join(defaultSshDir, "id_ed25519"),
+      DUMMY_RSA_PRIVATE_KEY_CONTENT,
+    );
+    ensureTargetDirectories();
+
+    const keys = await findAllAgeKeys();
+    expect(keys).toContain(EXPECTED_AGE_KEY_FROM_DUMMY_ED25519);
+  });
+
+  test("should prefer id_ed25519 over id_rsa when both exist", async () => {
+    setEnvVars({
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: mockAppDataDir,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+    });
+
+    const defaultSshDir = join(mockHomeDir, ".ssh");
+    mkdirSync(defaultSshDir, { recursive: true });
+
+    // Create both keys
+    writeFileSync(
+      join(defaultSshDir, "id_ed25519"),
+      DUMMY_ED25519_PRIVATE_KEY_CONTENT,
+    );
+    writeFileSync(join(defaultSshDir, "id_rsa"), DUMMY_RSA_PRIVATE_KEY_CONTENT);
+    ensureTargetDirectories();
+
+    const keys = await findAllAgeKeys();
+    expect(keys).toContain(EXPECTED_AGE_KEY_FROM_DUMMY_ED25519);
+  });
+
+  test("should fall back to id_rsa when id_ed25519 doesn't exist", async () => {
+    setEnvVars({
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: mockAppDataDir,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+    });
+
+    const defaultSshDir = join(mockHomeDir, ".ssh");
+    mkdirSync(defaultSshDir, { recursive: true });
+
+    // Create only RSA key
+    writeFileSync(join(defaultSshDir, "id_rsa"), DUMMY_RSA_PRIVATE_KEY_CONTENT);
+    ensureTargetDirectories();
+
+    const keys = await findAllAgeKeys();
+    expect(keys.length).toBeGreaterThanOrEqual(1);
+    keys.forEach((key) => {
+      expect(key).toMatch(/^AGE-SECRET-KEY-1[A-Z0-9]+$/);
+    });
+  });
+
+  test("should combine keys from multiple sources", async () => {
+    const sshKeyPath = join(tempRootDir, "additional.key");
+    writeFileSync(sshKeyPath, DUMMY_ED25519_PRIVATE_KEY_CONTENT);
+
+    setEnvVars({
+      SOPS_AGE_KEY: MOCK_AGE_KEY_1,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: sshKeyPath,
+      HOME: mockHomeDir,
+    });
+
+    const keys = await findAllAgeKeys();
+    expect(keys).toContain(MOCK_AGE_KEY_1);
+    expect(keys).toContain(EXPECTED_AGE_KEY_FROM_DUMMY_ED25519);
+    expect(keys.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("Key Format Validation", () => {
+  test("should accept both uppercase and lowercase age keys in files", async () => {
+    const keyFilePath = join(tempRootDir, "mixed_case_keys.txt");
+    const mixedCaseContent = `
+# Test file with mixed case keys
+AGE-SECRET-KEY-1TESTKEY1ABCDEFGHIJKLMNOPQRSTUVWXYZ012345
+age-secret-key-1testkey2abcdefghijklmnopqrstuvwxyz543210
+    `.trim();
+
+    writeFileSync(keyFilePath, mixedCaseContent);
+    setEnvVars({ SOPS_AGE_KEY_FILE: keyFilePath });
+
+    const keys = await findAllAgeKeys();
+    expect(keys).toContain(
+      "AGE-SECRET-KEY-1TESTKEY1ABCDEFGHIJKLMNOPQRSTUVWXYZ012345",
+    );
+    expect(keys).toContain(
+      "age-secret-key-1testkey2abcdefghijklmnopqrstuvwxyz543210",
+    );
+  });
+
+  test("should handle comments and empty lines in key files", async () => {
+    const keyFilePath = join(tempRootDir, "commented_keys.txt");
+    const commentedContent = `
+# This is a comment
+${MOCK_AGE_KEY_1}
+
+# Another comment
+# ${MOCK_AGE_KEY_2}
+
+${MOCK_AGE_KEY_2}
+    `.trim();
+
+    writeFileSync(keyFilePath, commentedContent);
+    setEnvVars({ SOPS_AGE_KEY_FILE: keyFilePath });
+
+    const keys = await findAllAgeKeys();
+    expect(keys).toContain(MOCK_AGE_KEY_1);
+    expect(keys).toContain(MOCK_AGE_KEY_2);
+  });
+
+  test("should warn about unsupported AGE plugin keys", async () => {
+    const keyFilePath = join(tempRootDir, "plugin_keys.txt");
+    const pluginContent = `
+${MOCK_AGE_KEY_1}
+AGE-PLUGIN-YUBIKEY-1ABCDEFGHIJKLMNOPQRSTUVWXYZ
+    `.trim();
+
+    writeFileSync(keyFilePath, pluginContent);
+    setEnvVars({ SOPS_AGE_KEY_FILE: keyFilePath });
+
+    // Capture console.warn calls
+    const originalWarn = console.warn;
+    const warnCalls: string[] = [];
+    console.warn = (message: string) => warnCalls.push(message);
+
+    try {
+      const keys = await findAllAgeKeys();
+      expect(keys).toContain(MOCK_AGE_KEY_1);
+      expect(
+        warnCalls.some((call) =>
+          call.includes("AGE plugin keys are not supported"),
+        ),
+      ).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+describe("RSA vs Ed25519 Conversion Consistency", () => {
+  test("should produce consistent results for the same RSA key", () => {
+    const ageKey1 = sshKeyToAge(DUMMY_RSA_PRIVATE_KEY_CONTENT, "test-rsa-1");
+    const ageKey2 = sshKeyToAge(DUMMY_RSA_PRIVATE_KEY_CONTENT, "test-rsa-2");
+
+    expect(ageKey1).toBe(ageKey2);
+    expect(ageKey1).not.toBeNull();
+  });
+
+  test("should produce consistent results for the same Ed25519 key", () => {
+    const ageKey1 = sshKeyToAge(
+      DUMMY_ED25519_PRIVATE_KEY_CONTENT,
+      "test-ed25519-1",
+    );
+    const ageKey2 = sshKeyToAge(
+      DUMMY_ED25519_PRIVATE_KEY_CONTENT,
+      "test-ed25519-2",
+    );
+
+    expect(ageKey1).toBe(ageKey2);
+    expect(ageKey1).toBe(EXPECTED_AGE_KEY_FROM_DUMMY_ED25519);
+  });
+
+  test("should produce different keys for different RSA keys", () => {
+    // We'd need another RSA key to test this properly
+    // For now, just verify our dummy RSA key produces a valid result
+    const ageKey = sshKeyToAge(DUMMY_RSA_PRIVATE_KEY_CONTENT, "test-rsa");
+    expect(ageKey).not.toBeNull();
+    expect(ageKey).toMatch(/^AGE-SECRET-KEY-1[A-Z0-9]+$/);
+    expect(ageKey).not.toBe(EXPECTED_AGE_KEY_FROM_DUMMY_ED25519);
+  });
+});
+
+describe("findAllAgeKeys()", () => {
+  test("should throw if no sources provide keys and default keys.txt is missing", async () => {
+    setEnvVars({
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: mockAppDataDir,
+      SOPS_AGE_KEY: undefined,
+      SOPS_AGE_KEY_FILE: undefined,
+      SOPS_AGE_KEY_CMD: undefined,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+    });
+    ensureTargetDirectories();
+
+    await expect(findAllAgeKeys()).rejects.toThrow();
+  });
+
+  test("should return empty array no sources provide keys and default keys.txt is empty", async () => {
+    // Simulate Linux by setting HOME and XDG_CONFIG_HOME
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      writable: true,
+      configurable: true,
+    });
+
+    setEnvVars({
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: undefined,
+      SOPS_AGE_KEY: undefined,
+      SOPS_AGE_KEY_FILE: undefined,
+      SOPS_AGE_KEY_CMD: undefined,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+    });
+
+    const sopsKeysDirForXDG = join(mockXdgConfigHome, "sops", "age");
+    mkdirSync(sopsKeysDirForXDG, { recursive: true });
+    writeFileSync(join(sopsKeysDirForXDG, "keys.txt"), "# comment only");
+    mkdirSync(join(mockHomeDir, ".ssh"), { recursive: true });
+
+    try {
+      const keys = await findAllAgeKeys();
+      expect(keys).toEqual([]);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  test("should load key from SOPS_AGE_KEY", async () => {
+    setEnvVars({ SOPS_AGE_KEY: MOCK_AGE_KEY_1 });
+    const keys = await findAllAgeKeys();
+    expect(keys).toContain(MOCK_AGE_KEY_1);
+  });
+
+  test("should throw if SOPS_AGE_KEY_FILE is set but file not found", async () => {
+    const keyFilePath = join(tempRootDir, "non_existent_keys.txt");
+    setEnvVars({ SOPS_AGE_KEY_FILE: keyFilePath });
+
+    await expect(findAllAgeKeys()).rejects.toThrow(
+      `Failed to read SOPS_AGE_KEY_FILE (${keyFilePath})`,
+    );
+  });
+
+  test("should load key from SOPS_AGE_KEY_CMD (real exec)", async () => {
+    const cmd = `node -e "console.log('${MOCK_AGE_KEY_1}')"`;
+    setEnvVars({ SOPS_AGE_KEY_CMD: cmd });
+
+    const keys = await findAllAgeKeys();
+    expect(keys).toContain(MOCK_AGE_KEY_1);
+  });
+
+  test("should load key from SOPS_AGE_KEY_FILE", async () => {
+    const keyFilePath = join(tempRootDir, "my_age_keys_for_env_file.txt");
+    writeFileSync(keyFilePath, MOCK_AGE_KEY_1);
+    setEnvVars({
+      SOPS_AGE_KEY_FILE: keyFilePath,
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: mockAppDataDir,
+    });
+    ensureTargetDirectories();
+
+    const keys = await findAllAgeKeys();
+    expect(keys).toContain(MOCK_AGE_KEY_1);
+  });
+
+  test("should load key from SOPS_AGE_SSH_PRIVATE_KEY_FILE", async () => {
+    const sshKeyPath = join(tempRootDir, "dummy_id_for_env.key");
+    writeFileSync(sshKeyPath, DUMMY_ED25519_PRIVATE_KEY_CONTENT);
+    setEnvVars({
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: sshKeyPath,
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: mockAppDataDir,
+    });
+    ensureTargetDirectories();
+
+    const keys = await findAllAgeKeys();
+    expect(keys).toContain(EXPECTED_AGE_KEY_FROM_DUMMY_ED25519);
+  });
+
+  test("should load key from default .ssh/id_ed25519", async () => {
+    setEnvVars({
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: mockAppDataDir,
+      SOPS_AGE_KEY: undefined,
+      SOPS_AGE_KEY_FILE: undefined,
+      SOPS_AGE_KEY_CMD: undefined,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+    });
+
+    const defaultSshDir = join(mockHomeDir, ".ssh");
+    mkdirSync(defaultSshDir, { recursive: true });
+    const defaultSshKeyPath = join(defaultSshDir, "id_ed25519");
+    writeFileSync(defaultSshKeyPath, DUMMY_ED25519_PRIVATE_KEY_CONTENT);
+
+    mkdirSync(join(mockXdgConfigHome, "sops", "age"), { recursive: true });
+    mkdirSync(join(mockAppDataDir, "sops", "age"), { recursive: true });
+
+    const keys = await findAllAgeKeys();
+    expect(keys).toContain(EXPECTED_AGE_KEY_FROM_DUMMY_ED25519);
+  });
+
+  test("should load key from default sops/age/keys.txt (Linux simulation)", async () => {
+    // Simulate Linux by setting HOME and XDG_CONFIG_HOME
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      writable: true,
+      configurable: true,
+    });
+
+    setEnvVars({
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: mockXdgConfigHome,
+      APPDATA: undefined,
+      SOPS_AGE_KEY: undefined,
+      SOPS_AGE_KEY_FILE: undefined,
+      SOPS_AGE_KEY_CMD: undefined,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+    });
+
+    const sopsKeysDirForXDG = join(mockXdgConfigHome, "sops", "age");
+    mkdirSync(sopsKeysDirForXDG, { recursive: true });
+    writeFileSync(join(sopsKeysDirForXDG, "keys.txt"), MOCK_AGE_KEY_1);
+
+    mkdirSync(join(mockHomeDir, ".ssh"), { recursive: true });
+
+    try {
+      const keys = await findAllAgeKeys();
+      expect(keys).toContain(MOCK_AGE_KEY_1);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  test("should load key from default sops/age/keys.txt (macOS simulation)", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      writable: true,
+      configurable: true,
+    });
+
+    // On macOS, XDG_CONFIG_HOME can be set, or it falls back to ~/Library/...
+    setEnvVars({
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: undefined,
+      APPDATA: undefined,
+      SOPS_AGE_KEY: undefined,
+      SOPS_AGE_KEY_FILE: undefined,
+      SOPS_AGE_KEY_CMD: undefined,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+    });
+
+    const sopsKeysDirForMacDefault = join(
+      mockHomeDir,
+      "Library",
+      "Application Support",
+      "sops",
+      "age",
+    );
+    mkdirSync(sopsKeysDirForMacDefault, { recursive: true });
+    writeFileSync(join(sopsKeysDirForMacDefault, "keys.txt"), MOCK_AGE_KEY_1);
+    mkdirSync(join(mockHomeDir, ".ssh"), { recursive: true });
+
+    try {
+      let keys = await findAllAgeKeys();
+      expect(keys).toContain(MOCK_AGE_KEY_1);
+
+      // Test 2: XDG_CONFIG_HOME IS set on macOS
+      rmSync(sopsKeysDirForMacDefault, { recursive: true, force: true });
+      const macXdgConfig = join(tempRootDir, "mac_xdg_config");
+      mkdirSync(macXdgConfig, { recursive: true });
+      const sopsKeysDirForMacXDG = join(macXdgConfig, "sops", "age");
+      mkdirSync(sopsKeysDirForMacXDG, { recursive: true });
+      writeFileSync(join(sopsKeysDirForMacXDG, "keys.txt"), MOCK_AGE_KEY_2);
+
+      setEnvVars({
+        HOME: mockHomeDir,
+        XDG_CONFIG_HOME: macXdgConfig,
+        APPDATA: undefined,
+        SOPS_AGE_KEY: undefined,
+        SOPS_AGE_KEY_FILE: undefined,
+        SOPS_AGE_KEY_CMD: undefined,
+        SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+      });
+      keys = await findAllAgeKeys();
+      expect(keys).toContain(MOCK_AGE_KEY_2);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  test("should load key from default sops/age/keys.txt (Windows simulation)", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "win32",
+      writable: true,
+      configurable: true,
+    });
+
+    setEnvVars({
+      HOME: mockHomeDir,
+      XDG_CONFIG_HOME: undefined,
+      APPDATA: mockAppDataDir,
+      SOPS_AGE_KEY: undefined,
+      SOPS_AGE_KEY_FILE: undefined,
+      SOPS_AGE_KEY_CMD: undefined,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+    });
+
+    const sopsKeysDirForWindows = join(mockAppDataDir, "sops", "age");
+    mkdirSync(sopsKeysDirForWindows, { recursive: true });
+    writeFileSync(join(sopsKeysDirForWindows, "keys.txt"), MOCK_AGE_KEY_1);
+    mkdirSync(join(mockHomeDir, ".ssh"), { recursive: true });
+
+    try {
+      const keys = await findAllAgeKeys();
+      expect(keys).toContain(MOCK_AGE_KEY_1);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+});
+
+describe("findAllAgeKeys() - SOPS Integration Tests", () => {
+  let tempDir: string;
+  let sopsFilePath: string; // Path to .sops.yaml
+  let secretFilePath: string; // Path to the original secret data
+  let encryptedFilePath: string; // Path to the SOPS encrypted file
+
+  const originalSecretData = "This is a super secret message!";
+
+  // Placeholders for generated keys and recipients
+  let ageRecipient: string;
+  let agePrivateKey: string; // The actual AGE-SECRET-KEY-1...
+  let sshEd25519Recipient: string; // ssh-ed25519 public key
+  let sshEd25519PrivateKeyPath: string;
+  let sshRsaRecipient: string; // ssh-rsa public key
+  let sshRsaPrivateKeyPath: string;
+
+  function runCmd(command: string, cwd?: string) {
+    return execSync(command, { cwd, stdio: "pipe", encoding: "utf-8" });
+  }
+
+  let clearEnv: () => void;
+
+  const setEnvVars = (vars: Record<string, string | undefined>) => {
+    const originalEnv: Record<string, string | undefined> = {};
+    Object.keys(vars).forEach((key) => {
+      originalEnv[key] = process.env[key];
+    });
+    if (process.env.NODE_ENV) originalEnv.NODE_ENV = process.env.NODE_ENV;
+
+    for (const key in vars) {
+      if (vars[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = vars[key];
+      }
+    }
+    clearEnv = () => {
+      for (const key in originalEnv) {
+        if (originalEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = originalEnv[key];
+        }
+      }
+      if (originalEnv.NODE_ENV) process.env.NODE_ENV = originalEnv.NODE_ENV;
+      else delete process.env.NODE_ENV;
+    };
+  };
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "sops-integration-"));
+
+    sopsFilePath = join(tempDir, ".sops.yaml");
+    secretFilePath = join(tempDir, "secret.txt");
+    encryptedFilePath = join(tempDir, "secret.enc.txt");
+    sshEd25519PrivateKeyPath = join(tempDir, "id_ed25519_int_test");
+    sshRsaPrivateKeyPath = join(tempDir, "id_rsa_int_test");
+
+    // 1. Generate age key pair
+    const ageKeyOutput = runCmd("age-keygen");
+    // Output is like:
+    // # created: 2023-10-27T12:00:00Z
+    // # public key: age1...
+    // AGE-SECRET-KEY-1...
+    ageRecipient = ageKeyOutput.match(/public key: (age1[a-z0-9]+)/)?.[1] || "";
+    agePrivateKey =
+      ageKeyOutput.match(/(AGE-SECRET-KEY-1[A-Z0-9]+)/)?.[0] || "";
+    if (!ageRecipient || !agePrivateKey) {
+      throw new Error("Failed to parse age-keygen output");
+    }
+
+    // 2. Generate SSH ed25519 key pair
+    runCmd(
+      `ssh-keygen -t ed25519 -f "${sshEd25519PrivateKeyPath}" -N "" -C "sops-integration-test@example.com"`,
+    );
+    const sshEd25519PublicKey = readFileSync(
+      `${sshEd25519PrivateKeyPath}.pub`,
+      "utf-8",
+    ).trim();
+    sshEd25519Recipient = sshEd25519PublicKey;
+
+    // 3. Generate RSA key pair
+    runCmd(
+      `ssh-keygen -t rsa -b 2048 -f "${sshRsaPrivateKeyPath}" -N "" -C "sops-integration-test-rsa@example.com"`,
+    );
+    const sshRsaPublicKey = readFileSync(
+      `${sshRsaPrivateKeyPath}.pub`,
+      "utf-8",
+    ).trim();
+    sshRsaRecipient = sshRsaPublicKey;
+
+    // 4. Write original secret
+    writeFileSync(secretFilePath, originalSecretData);
+
+    // 5. Create .sops.yaml configuration
+    const sopsConfig = {
+      creation_rules: [
+        {
+          path_regex: "secret\\.txt$",
+          age: `${ageRecipient},${sshEd25519Recipient},${sshRsaRecipient}`,
+        },
+      ],
+    };
+    writeFileSync(sopsFilePath, JSON.stringify(sopsConfig, null, 2));
+
+    // 6. Encrypt the file with sops
+    runCmd(
+      `sops --config "${sopsFilePath}" -e "${secretFilePath}" > "${encryptedFilePath}"`,
+      tempDir,
+    );
+    expect(existsSync(encryptedFilePath)).toBe(true);
+  });
+
+  afterAll(() => {
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+    if (clearEnv) {
+      clearEnv();
+    }
+  });
+
+  beforeEach(() => {
+    // Reset env vars that might be set by specific tests
+    setEnvVars({
+      HOME: undefined,
+      XDG_CONFIG_HOME: undefined,
+      APPDATA: undefined,
+      SOPS_AGE_KEY: undefined,
+      SOPS_AGE_KEY_FILE: undefined,
+      SOPS_AGE_KEY_CMD: undefined,
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: undefined,
+    });
+  });
+
+  async function attemptDecryptionWithFoundKeys(
+    foundKeys: string[],
+    targetEncryptedFilePath: string,
+  ): Promise<string> {
+    if (foundKeys.length === 0) {
+      throw new Error(
+        "No age keys found by findAllAgeKeys to attempt decryption.",
+      );
+    }
+    const tempKeyFilePath = join(tempDir, "temp-decrypt-keys.txt");
+
+    writeFileSync(tempKeyFilePath, foundKeys.join("\n"));
+
+    try {
+      const decryptedContent = runCmd(
+        `SOPS_AGE_KEY_FILE="${tempKeyFilePath}" sops -d "${targetEncryptedFilePath}"`,
+      );
+      return decryptedContent.trim();
+    } catch (error) {
+      console.error(
+        "Failed to decrypt with SOPS. Keys provided:",
+        foundKeys.join("\\n"),
+      );
+      throw new Error(`SOPS decryption failed: ${error}`);
+    } finally {
+      if (existsSync(tempKeyFilePath)) {
+        rmSync(tempKeyFilePath);
+      }
+    }
+  }
+
+  test("should discover age private key from default keys.txt and decrypt", async () => {
+    const mockUserHome = join(tempDir, "testuser_home_1");
+    const mockXdgConfig = join(mockUserHome, ".config"); // Linux
+    const sopsKeysDir = join(mockXdgConfig, "sops", "age");
+    mkdirSync(sopsKeysDir, { recursive: true });
+    writeFileSync(join(sopsKeysDir, "keys.txt"), agePrivateKey);
+
+    setEnvVars({
+      HOME: mockUserHome,
+      XDG_CONFIG_HOME: mockXdgConfig,
+    });
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      writable: true,
+      configurable: true,
+    });
+
+    try {
+      const discoveredKeys = await findAllAgeKeys();
+      expect(discoveredKeys).toContain(agePrivateKey);
+
+      const decryptedData = await attemptDecryptionWithFoundKeys(
+        discoveredKeys,
+        encryptedFilePath,
+      );
+      expect(decryptedData).toBe(originalSecretData);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  });
+
+  test("should discover SSH private key from SOPS_AGE_SSH_PRIVATE_KEY_FILE and decrypt", async () => {
+    setEnvVars({
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: sshEd25519PrivateKeyPath,
+      HOME: join(tempDir, "someotherhome"),
+    });
+
+    const discoveredKeys = await findAllAgeKeys();
+    const sshKeyContent = readFileSync(sshEd25519PrivateKeyPath, "utf-8");
+    const expectedConvertedSshKey = sshKeyToAge(
+      sshKeyContent,
+      sshEd25519PrivateKeyPath,
+    );
+
+    expect(expectedConvertedSshKey).not.toBeNull();
+    expect(discoveredKeys).toContain(expectedConvertedSshKey);
+
+    const decryptedData = await attemptDecryptionWithFoundKeys(
+      discoveredKeys,
+      encryptedFilePath,
+    );
+    expect(decryptedData).toBe(originalSecretData);
+  });
+
+  test("should discover RSA SSH private key and decrypt", async () => {
+    setEnvVars({
+      SOPS_AGE_SSH_PRIVATE_KEY_FILE: sshRsaPrivateKeyPath,
+      HOME: join(tempDir, "someotherhome3"),
+    });
+
+    const discoveredKeys = await findAllAgeKeys();
+    const sshKeyContent = readFileSync(sshRsaPrivateKeyPath, "utf-8");
+    const expectedConvertedSshKey = sshKeyToAge(
+      sshKeyContent,
+      sshRsaPrivateKeyPath,
+    );
+
+    expect(expectedConvertedSshKey).not.toBeNull();
+    expect(discoveredKeys).toContain(expectedConvertedSshKey);
+
+    const decryptedData = await attemptDecryptionWithFoundKeys(
+      discoveredKeys,
+      encryptedFilePath,
+    );
+    expect(decryptedData).toBe(originalSecretData);
+  });
+
+  test("should discover age private key from SOPS_AGE_KEY and decrypt", async () => {
+    setEnvVars({
+      SOPS_AGE_KEY: agePrivateKey,
+      HOME: join(tempDir, "someotherhome2"),
+    });
+
+    const discoveredKeys = await findAllAgeKeys();
+    expect(discoveredKeys).toContain(agePrivateKey);
+
+    const decryptedData = await attemptDecryptionWithFoundKeys(
+      discoveredKeys,
+      encryptedFilePath,
+    );
+    expect(decryptedData).toBe(originalSecretData);
+  });
+});

--- a/tests/unit/age-key.test.ts
+++ b/tests/unit/age-key.test.ts
@@ -215,12 +215,8 @@ ZXN0aW5nAQIDBAUG
   });
 
   test("should handle empty SSH key content", () => {
-    expect(() => sshKeyToAge("", "test-empty")).toThrow(
-      "SSH key should not be empty",
-    );
-    expect(() => sshKeyToAge("   \n  ", "test-whitespace")).toThrow(
-      "SSH key should not be empty",
-    );
+    expect(sshKeyToAge("", "test-empty")).toBe(null);
+    expect(sshKeyToAge("   \n  ", "test-whitespace")).toBe(null);
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,5 @@ export default defineConfig({
     },
     include: ["tests/unit/**/*.test.ts"],
     exclude: ["dist", "node_modules"],
-    setupFiles: ["console-fail-test/setup"],
   },
 });


### PR DESCRIPTION
For some other work I'm doing, I needed to get `ssh-to-age` like support, and also to handle the proper way that sops deals with discovering and trying multiple age keys when decrypting.

This now supports all the same mechanisms that sops uses with age keys, including automatic conversion of SSH keys.