### PR TITLE
Fix how sshpk gets imported

### DIFF
--- a/src/ssh-to-age.ts
+++ b/src/ssh-to-age.ts
@@ -1,6 +1,6 @@
 import { sha256, sha512 } from "@noble/hashes/sha2";
 import { bech32 } from "@scure/base";
-import * as sshpk from "sshpk";
+import sshpk from "sshpk";
 import { readFile } from "node:fs/promises";
 
 function clampX25519PrivateKey(key: Uint8Array): void {


### PR DESCRIPTION
The way we're importing sshpk is wrong, and breaks when used in an app after being bundled.